### PR TITLE
On error, inform user of log file location

### DIFF
--- a/crawl.sh
+++ b/crawl.sh
@@ -65,8 +65,8 @@ function nutch() {
         echo "Generate returned 1 (no segment created / no more URLs to fetch)"
     else
         echo "Error running:"
-        echo "  nutch $@"
-        echo "Failed with exit value $RETCODE."
+        echo "  $NUTCH_HOME/bin/nutch $nutch_tool $@"
+        echo "Failed with exit value $RETCODE (there may be more details in ${NUTCH_LOG_DIR}/hadoop.log )"
         exit $RETCODE
     fi
 }


### PR DESCRIPTION
On error, the file `crawl/logs/hadoop.log` may contain a full stack trace (which isn't printed to console). Inform the user in case they don't know about this.